### PR TITLE
Add:rate limiting to endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/valyala/fasthttp v1.41.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	gorm.io/driver/mysql v1.4.4 // indirect
 	gorm.io/gorm v1.24.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handlers/college.go
+++ b/handlers/college.go
@@ -4,13 +4,30 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
+	"golang.org/x/time/rate"
 	"github.com/PriyanKishoreMS/colleges-list-api/config"
 	"github.com/PriyanKishoreMS/colleges-list-api/entities"
 	"github.com/gofiber/fiber/v2"
 )
 
-func GetAllStates(c *fiber.Ctx) error {
+type APIhandler struct{
+	rateLimiter *rate.Limiter
+}
+func NewAPIhandler() *APIhandler {
+	return &APIhandler{
+		//bucket size 10 and refill rate is 3/sec
+		rateLimiter: rate.NewLimiter(rate.Every(time.Second)*3,10),
+	}
+}
+
+func(handlerObj *APIhandler) GetAllStates(c *fiber.Ctx) error {
+
+	err := handlerObj.rateLimiter.Wait(c.Context())
+	if  err != nil{
+		return err
+	}
 
 	var states []string
 
@@ -26,7 +43,12 @@ func GetAllStates(c *fiber.Ctx) error {
 	return c.Status(http.StatusOK).JSON(states)
 }
 
-func GetDistrictsByState(c *fiber.Ctx) error {
+func(handlerObj *APIhandler) GetDistrictsByState(c *fiber.Ctx) error {
+
+	err := handlerObj.rateLimiter.Wait(c.Context())
+	if  err != nil{
+		return err
+	}
 
 	state := c.Params("state")
 	var districts []string
@@ -42,7 +64,12 @@ func GetDistrictsByState(c *fiber.Ctx) error {
 	return c.Status(http.StatusOK).JSON(districts)
 }
 
-func GetAllCollegesInState(c *fiber.Ctx) error {
+func(handlerObj *APIhandler) GetAllCollegesInState(c *fiber.Ctx) error {
+
+	err := handlerObj.rateLimiter.Wait(c.Context())
+	if  err != nil{
+		return err
+	}
 
 	state := c.Params("state")
 	page, _ := strconv.Atoi(c.Query("page", "1"))
@@ -83,7 +110,12 @@ func GetAllCollegesInState(c *fiber.Ctx) error {
 	})
 }
 
-func GetAllCollegesInDistrict(c *fiber.Ctx) error {
+func (handlerObj *APIhandler) GetAllCollegesInDistrict(c *fiber.Ctx) error {
+
+	err := handlerObj.rateLimiter.Wait(c.Context())
+	if  err != nil{
+		return err
+	}	
 
 	state := c.Params("state")
 	district := c.Params("district")
@@ -127,7 +159,12 @@ func GetAllCollegesInDistrict(c *fiber.Ctx) error {
 
 }
 
-func SearchCollege(c *fiber.Ctx) error {
+func (handlerObj *APIhandler) SearchCollege(c *fiber.Ctx) error {
+
+	err := handlerObj.rateLimiter.Wait(c.Context())
+	if  err != nil{
+		return err
+	}	
 
 	search := c.Query("search")
 	page, _ := strconv.Atoi(c.Query("page", "1"))

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func main() {
 	app := fiber.New()
 
 	config.Connect()
+	handlerObj := handlers.NewAPIhandler();
 
 	app.Static("/", "./public")
 
@@ -20,11 +21,11 @@ func main() {
 		return c.SendFile("./public/index.html")
 	})
 
-	app.Get("colleges/", handlers.SearchCollege)
-	app.Get("colleges/states", handlers.GetAllStates)
-	app.Get("colleges/:state/districts", handlers.GetDistrictsByState)
-	app.Get("colleges/:state", handlers.GetAllCollegesInState)
-	app.Get("colleges/:state/:district", handlers.GetAllCollegesInDistrict)
+	app.Get("colleges/", handlerObj.SearchCollege)
+	app.Get("colleges/states", handlerObj.GetAllStates)
+	app.Get("colleges/:state/districts", handlerObj.GetDistrictsByState)
+	app.Get("colleges/:state", handlerObj.GetAllCollegesInState)
+	app.Get("colleges/:state/:district", handlerObj.GetAllCollegesInDistrict)
 
 	log.Fatal(app.Listen(":3000"))
 }


### PR DESCRIPTION
Implements token  bucket based rate limiting for all endpoints to prevent database crash or system overload.
Config is set to handle 10 burst requests and 3 requests per second when exceeding that.